### PR TITLE
add zenodo live test

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -84,7 +84,7 @@ jobs:
         - name: Convert CITATION.cff from a subdirectory to Zenodo metadata format, show result on stdout
           uses: ./
           with:
-            args: "--infile ./tests/zenodo-equivalent/CITATION.cff --format zenodo > .zenodo.test.json"
+            args: "--infile ./tests/zenodo-equivalent/CITATION.cff --format zenodo --outfile .zenodo.test.json"
         - name: Compare the generated .zenodo.json with the expected
           run: |
             diff <(jq -S . .zenodo.test.json) <(jq -S . ./tests/zenodo-equivalent/.zenodo.json)

--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -64,7 +64,7 @@ jobs:
         - name: Show CITATION.cff from a subdirectory on stdout
           uses: ./
           with:
-            args: "--infile ./tests/subdirectory/CITATION.cff -f cff"
+            args: "--infile ./tests/subdirectory/CITATION.cff --format cff"
 
   convert-to-zenodo-on-stdout:
       runs-on: ubuntu-latest
@@ -74,4 +74,4 @@ jobs:
         - name: Convert CITATION.cff from a subdirectory to Zenodo metadata format, show result on stdout
           uses: ./
           with:
-            args: "--infile ./tests/subdirectory/CITATION.cff -f zenodo"
+            args: "--infile ./tests/subdirectory/CITATION.cff --format zenodo"

--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -75,3 +75,16 @@ jobs:
           uses: ./
           with:
             args: "--infile ./tests/subdirectory/CITATION.cff --format zenodo"
+
+  convert-to-zenodo-and-compare:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Clone this repository
+          uses: actions/checkout@v2
+        - name: Convert CITATION.cff from a subdirectory to Zenodo metadata format, show result on stdout
+          uses: ./
+          with:
+            args: "--infile ./tests/zenodo-equivalent/CITATION.cff --format zenodo > .zenodo.test.json"
+        - name: Compare the generated .zenodo.json with the expected
+          run: |
+            diff <(jq -S . .zenodo.test.json) <(jq -S . ./tests/zenodo-equivalent/.zenodo.json)

--- a/tests/zenodo-equivalent/.zenodo.json
+++ b/tests/zenodo-equivalent/.zenodo.json
@@ -1,0 +1,13 @@
+{
+    "creators": [
+        {
+            "name": "Spaaks, Jurriaan H."
+        }
+    ],
+    "license": {
+        "id": "Apache-2.0"
+    },
+    "publication_date": "2020-08-21",
+    "title": "cffconvert GitHub Action",
+    "version": "0.1.0"
+}

--- a/tests/zenodo-equivalent/CITATION.cff
+++ b/tests/zenodo-equivalent/CITATION.cff
@@ -1,0 +1,13 @@
+# YAML 1.2
+---
+authors: 
+  -
+    family-names: Spaaks
+    given-names: "Jurriaan H."
+cff-version: "1.1.0"
+date-released: 2020-08-21
+license: "Apache-2.0"
+message: "If you use this software, please cite it using these metadata."
+title: "cffconvert GitHub Action"
+version: 0.1.0
+...


### PR DESCRIPTION
**Description**

This PR adds a new live test. A CITATION.cff file (tests/zenodo-equivalent/CITATION.cff) is converted to zenodo format and compared with the expected result (tests/zenodo-equivalent/.zenodo.json)

**Related issues**:
- #41 

**Instructions to review the pull request**
Check `convert-to-zenodo-and-compare` job in `.github/workflows/selftest.yml`
