### PR TITLE
Update cffconvert.yml

### DIFF
--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -3,8 +3,8 @@ name: cffconvert
 on: push
 
 jobs:
-  verify:
-    name: "cffconvert"
+  validate:
+    name: "validate"
     runs-on: ubuntu-latest
     steps:
       - name: Check out a copy of the repository

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ name: cffconvert
 on: push
 
 jobs:
-  verify:
-    name: "cffconvert"
+  validate:
+    name: "validate"
     runs-on: ubuntu-latest
     steps:
       - name: Check out a copy of the repository
@@ -49,8 +49,8 @@ name: cffconvert
 on: push
 
 jobs:
-  verify:
-    name: "cffconvert"
+  validate:
+    name: "validate"
     runs-on: ubuntu-latest
     steps:
       - name: Check out a copy of the repository
@@ -71,8 +71,8 @@ name: cffconvert
 on: push
 
 jobs:
-  verify:
-    name: "cffconvert"
+  convert:
+    name: "convert"
     runs-on: ubuntu-latest
     steps:
       - name: Check out a copy of the repository


### PR DESCRIPTION
**Description**

more accurate names for workflow jobs

**Related issues**:
- N/A

**Instructions to review the pull request**

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cffaction-XXXXXX)
git clone https://github.com/citation-file-format/cffconvert-github-action .
git checkout <this-branch>
```
-->

How it shows up in the PR 

![image](https://user-images.githubusercontent.com/4558105/150372318-424a5d5a-bee9-408f-9e20-c8c1c0559a24.png)

(In contrast, a conversion to e.g. zenodo would be listed as `cffconvert / convert`)


