### PR TITLE
Add fair-software.nl recommended badges

### DIFF
--- a/.github/workflows/fair-software.yml
+++ b/.github/workflows/fair-software.yml
@@ -1,0 +1,15 @@
+name: fair-software
+
+on: push
+
+jobs:
+  verify:
+    name: "fair-software"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fair-software/howfairis-github-action@0.2.0
+        name: Measure compliance with fair-software.eu recommendations
+        env:
+          PYCHARM_HOSTED: "Trick colorama into displaying colored output" 
+        with:
+          MY_REPO_URL: "https://github.com/${{ github.repository }}"

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,4 +1,4 @@
-name: Check Markdown links
+name: links
 
 on: push
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ GitHub action to validate CITATION.cff files, and convert to other citation form
 | (3/5) community registry           | [![github marketplace badge](https://img.shields.io/badge/github-marketplace-000.svg?logo=github&labelColor=gray&color=blue)](https://github.com/marketplace/actions/cffconvert) [![Research Software Directory](https://img.shields.io/badge/rsd-cffconvert-github-action-00a3e3.svg)](https://www.research-software.nl/software/cffconvert-github-action) |
 | (4/5) citation                     | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3993241.svg)](https://doi.org/10.5281/zenodo.3993241) |
 | (5/5) checklist                    |  |
-| overall                            | [![fair-software badge](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F-green)](https://fair-software.eu) |
+| overall                            | [![fair-software.eu](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8B-yellow)](https://fair-software.eu) |
 | **GitHub Actions**
 | Testing | [![testing](https://github.com/citation-file-format/cffconvert-github-action/workflows/selftest/badge.svg)](https://github.com/citation-file-format/cffconvert-github-action/actions?query=workflow%3A%22selftest%22) |
 | Citation metadata | [![citation metadata](https://github.com/citation-file-format/cffconvert-github-action/workflows/cffconvert/badge.svg)](https://github.com/citation-file-format/cffconvert-github-action/actions?query=workflow%3A%22cffconvert%22) |
 | Markdown links | [![links](https://github.com/citation-file-format/cffconvert-github-action/actions/workflows/link-check.yml/badge.svg)](https://github.com/citation-file-format/cffconvert-github-action/actions/workflows/link-check.yml) |
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,20 @@ GitHub action to validate CITATION.cff files, and convert to other citation form
 
 ## Badges
 
-| Description | Badge |
-| --- | --- |
-| Zenodo | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3993241.svg)](https://doi.org/10.5281/zenodo.3993241) |
+| fair-software.nl recommendations | |
+| :-- | :--  |
+| (1/5) code repository              | [![github repo badge](https://img.shields.io/badge/github-repo-000.svg?logo=github&labelColor=gray&color=blue)](https://github.com/citation-file-format/cffconvert-github-action) |
+| (2/5) license                      | [![github license badge](https://img.shields.io/github/license/citation-file-format/cffconvert-github-action)](https://github.com/citation-file-format/cffconvert-github-action) |
+| (3/5) community registry           | [![github marketplace badge](https://img.shields.io/badge/github-marketplace-000.svg?logo=github&labelColor=gray&color=blue)](https://github.com/marketplace/actions/cffconvert) [![Research Software Directory](https://img.shields.io/badge/rsd-cffconvert-github-action-00a3e3.svg)](https://www.research-software.nl/software/cffconvert-github-action) |
+| (4/5) citation                     | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3993241.svg)](https://doi.org/10.5281/zenodo.3993241) |
+| (5/5) checklist                    |  |
+| overall                            | [![fair-software badge](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F-green)](https://fair-software.eu) |
+| **GitHub Actions**
 | Testing | [![testing](https://github.com/citation-file-format/cffconvert-github-action/workflows/selftest/badge.svg)](https://github.com/citation-file-format/cffconvert-github-action/actions?query=workflow%3A%22selftest%22) |
 | Citation metadata | [![citation metadata](https://github.com/citation-file-format/cffconvert-github-action/workflows/cffconvert/badge.svg)](https://github.com/citation-file-format/cffconvert-github-action/actions?query=workflow%3A%22cffconvert%22) |
-| Markdown links | [![Check Markdown links](https://github.com/citation-file-format/cffconvert-github-action/actions/workflows/link-check.yml/badge.svg)](https://github.com/citation-file-format/cffconvert-github-action/actions/workflows/link-check.yml) |
+| Markdown links | [![links](https://github.com/citation-file-format/cffconvert-github-action/actions/workflows/link-check.yml/badge.svg)](https://github.com/citation-file-format/cffconvert-github-action/actions/workflows/link-check.yml) |
+
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,16 @@
 
 GitHub action to validate CITATION.cff files, and convert to other citation formats using dockerized version of [cffconvert](https://pypi.org/project/cffconvert/).
 
-## Badges
-
-| fair-software.nl recommendations | |
-| :-- | :--  |
-| (1/5) code repository              | [![github repo badge](https://img.shields.io/badge/github-repo-000.svg?logo=github&labelColor=gray&color=blue)](https://github.com/citation-file-format/cffconvert-github-action) |
-| (2/5) license                      | [![github license badge](https://img.shields.io/github/license/citation-file-format/cffconvert-github-action)](https://github.com/citation-file-format/cffconvert-github-action) |
-| (3/5) community registry           | [![github marketplace badge](https://img.shields.io/badge/github-marketplace-000.svg?logo=github&labelColor=gray&color=blue)](https://github.com/marketplace/actions/cffconvert) [![Research Software Directory](https://img.shields.io/badge/rsd-cffconvert--github--action-00a3e3.svg)](https://www.research-software.nl/software/cffconvert-github-action) |
-| (4/5) citation                     | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3993241.svg)](https://doi.org/10.5281/zenodo.3993241) |
-| (5/5) checklist                    |  |
-| overall                            | [![fair-software.eu](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8B-yellow)](https://fair-software.eu) |
-| **GitHub Actions**
-| Testing | [![testing](https://github.com/citation-file-format/cffconvert-github-action/workflows/selftest/badge.svg)](https://github.com/citation-file-format/cffconvert-github-action/actions?query=workflow%3A%22selftest%22) |
-| Citation metadata | [![citation metadata](https://github.com/citation-file-format/cffconvert-github-action/workflows/cffconvert/badge.svg)](https://github.com/citation-file-format/cffconvert-github-action/actions?query=workflow%3A%22cffconvert%22) |
-| Markdown links | [![links](https://github.com/citation-file-format/cffconvert-github-action/actions/workflows/link-check.yml/badge.svg)](https://github.com/citation-file-format/cffconvert-github-action/actions/workflows/link-check.yml) |
-| fair-software.eu | [![fair software badge](https://github.com/citation-file-format/cffconvert-github-action/actions/workflows/fair-software.yml/badge.svg)](https://github.com/citation-file-format/cffconvert-github-action/actions/workflows/fair-software.yml) |
-
+[![github repo badge](https://img.shields.io/badge/github-repo-000.svg?logo=github&labelColor=gray&color=blue)](https://github.com/citation-file-format/cffconvert-github-action)
+[![github license badge](https://img.shields.io/github/license/citation-file-format/cffconvert-github-action)](https://github.com/citation-file-format/cffconvert-github-action)
+[![github marketplace badge](https://img.shields.io/badge/github-marketplace-000.svg?logo=github&labelColor=gray&color=blue)](https://github.com/marketplace/actions/cffconvert)
+[![Research Software Directory](https://img.shields.io/badge/rsd-cffconvert--github--action-00a3e3.svg)](https://www.research-software.nl/software/cffconvert-github-action)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3993241.svg)](https://doi.org/10.5281/zenodo.3993241)
+[![fair-software.eu](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8B-yellow)](https://fair-software.eu)
+[![testing](https://github.com/citation-file-format/cffconvert-github-action/workflows/selftest/badge.svg)](https://github.com/citation-file-format/cffconvert-github-action/actions?query=workflow%3A%22selftest%22)
+[![citation metadata](https://github.com/citation-file-format/cffconvert-github-action/workflows/cffconvert/badge.svg)](https://github.com/citation-file-format/cffconvert-github-action/actions?query=workflow%3A%22cffconvert%22)
+[![links](https://github.com/citation-file-format/cffconvert-github-action/actions/workflows/link-check.yml/badge.svg)](https://github.com/citation-file-format/cffconvert-github-action/actions/workflows/link-check.yml)
+[![fair software badge](https://github.com/citation-file-format/cffconvert-github-action/actions/workflows/fair-software.yml/badge.svg)](https://github.com/citation-file-format/cffconvert-github-action/actions/workflows/fair-software.yml)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ GitHub action to validate CITATION.cff files, and convert to other citation form
 | Testing | [![testing](https://github.com/citation-file-format/cffconvert-github-action/workflows/selftest/badge.svg)](https://github.com/citation-file-format/cffconvert-github-action/actions?query=workflow%3A%22selftest%22) |
 | Citation metadata | [![citation metadata](https://github.com/citation-file-format/cffconvert-github-action/workflows/cffconvert/badge.svg)](https://github.com/citation-file-format/cffconvert-github-action/actions?query=workflow%3A%22cffconvert%22) |
 | Markdown links | [![links](https://github.com/citation-file-format/cffconvert-github-action/actions/workflows/link-check.yml/badge.svg)](https://github.com/citation-file-format/cffconvert-github-action/actions/workflows/link-check.yml) |
-
-
+| fair-software.eu | [![fair software badge](https://github.com/citation-file-format/cffconvert-github-action/actions/workflows/fair-software.yml/badge.svg)](https://github.com/citation-file-format/cffconvert-github-action/actions/workflows/fair-software.yml) |
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ GitHub action to validate CITATION.cff files, and convert to other citation form
 | :-- | :--  |
 | (1/5) code repository              | [![github repo badge](https://img.shields.io/badge/github-repo-000.svg?logo=github&labelColor=gray&color=blue)](https://github.com/citation-file-format/cffconvert-github-action) |
 | (2/5) license                      | [![github license badge](https://img.shields.io/github/license/citation-file-format/cffconvert-github-action)](https://github.com/citation-file-format/cffconvert-github-action) |
-| (3/5) community registry           | [![github marketplace badge](https://img.shields.io/badge/github-marketplace-000.svg?logo=github&labelColor=gray&color=blue)](https://github.com/marketplace/actions/cffconvert) [![Research Software Directory](https://img.shields.io/badge/rsd-cffconvert-github-action-00a3e3.svg)](https://www.research-software.nl/software/cffconvert-github-action) |
+| (3/5) community registry           | [![github marketplace badge](https://img.shields.io/badge/github-marketplace-000.svg?logo=github&labelColor=gray&color=blue)](https://github.com/marketplace/actions/cffconvert) [![Research Software Directory](https://img.shields.io/badge/rsd-cffconvert--github--action-00a3e3.svg)](https://www.research-software.nl/software/cffconvert-github-action) |
 | (4/5) citation                     | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3993241.svg)](https://doi.org/10.5281/zenodo.3993241) |
 | (5/5) checklist                    |  |
 | overall                            | [![fair-software.eu](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8B-yellow)](https://fair-software.eu) |


### PR DESCRIPTION
**Description**

This PR adds a few badges 

**Related issues**:
- N/A

**Instructions to review the pull request**

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cffaction-XXXXXX)
git clone https://github.com/citation-file-format/cffconvert-github-action .
git checkout <this-branch>
```
-->

Review online by reading the readme. Note:
- the fair-software workflow should start working once it's merged
- the link check complains about doi.org and zenodo.org, they are having server-side problems at the moment

Question: should we put the badges lower down in the document? Maybe it's a bit much like it is 
