### PR TITLE
Update cffconvert.yml

### DIFF
--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -11,8 +11,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check whether the citation metadata from CITATION.cff is valid
-        #uses: citation-file-format/cffconvert-github-action@2.0.0
-        uses: ./
+        uses: citation-file-format/cffconvert-github-action@2.0.0
         with:
           args: "--validate"
         


### PR DESCRIPTION
**Description**

Updates cffconvert workflow so that it tries to use citation-file-format/cffconvert-github-action@2.0.0 (which will be released shortyl)

**Related issues**:
- #34

**Instructions to review the pull request**

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cffaction-XXXXXX)
git clone https://github.com/citation-file-format/cffconvert-github-action .
git checkout <this-branch>
```
-->

Review online.
