### PR TITLE
Update actions/checkout to v4

### DIFF
--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out a copy of the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check whether the citation metadata from CITATION.cff is valid
         uses: citation-file-format/cffconvert-github-action@2.0.0

--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -12,7 +12,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Clone this repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v4
         - name: Test without any input arguments
           uses: ./
 
@@ -20,7 +20,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Clone this repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v4
         - name: Show help
           uses: ./
           with:
@@ -30,7 +30,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Clone this repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v4
         - name: Show version
           uses: ./
           with:
@@ -40,7 +40,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Clone this repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v4
         - name: Validate a CITATION.cff file from the current directory
           uses: ./
           with:
@@ -50,7 +50,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Clone this repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v4
         - name: Validate a CITATION.cff from a subdirectory
           uses: ./
           with:
@@ -60,7 +60,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Clone this repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v4
         - name: Show CITATION.cff from a subdirectory on stdout
           uses: ./
           with:
@@ -70,7 +70,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Clone this repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v4
         - name: Convert CITATION.cff from a subdirectory to Zenodo metadata format, show result on stdout
           uses: ./
           with:
@@ -80,7 +80,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Clone this repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v4
         - name: Convert CITATION.cff from a subdirectory to Zenodo metadata format, show result on stdout
           uses: ./
           with:

--- a/README.advanced.md
+++ b/README.advanced.md
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out a copy of the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Validate a CITATION.cff from a subdirectory
         uses: citation-file-format/cffconvert-github-action@2.0.0
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out a copy of the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Convert CITATION.cff to Zenodo metadata format
         uses: citation-file-format/cffconvert-github-action@2.0.0
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out a copy of the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Convert CITATION.cff to Zenodo metadata format
         uses: citation-file-format/cffconvert-github-action@2.0.0

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out a copy of the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check whether the citation metadata from CITATION.cff is valid
         uses: citation-file-format/cffconvert-github-action@2.0.0


### PR DESCRIPTION
**Description**

Manually bumps [actions/checkout](https://github.com/actions/checkout) from `v2` to `v4` (and updates example in README accordingly).

**Related issues**:
- https://github.com/actions/checkout/issues/959#issuecomment-1342479774
- https://github.blog/changelog/2023-07-17-github-actions-removal-of-node12-from-the-actions-runner/
